### PR TITLE
Downgraded Meziantou.Analyzer from 1.0.638 to 1.0.606

### DIFF
--- a/build/code-analysis.props
+++ b/build/code-analysis.props
@@ -10,7 +10,7 @@
   <ItemGroup Label="NuGet">
     <PackageReference Include="AsyncFixer" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="all" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.638" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.606" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" PrivateAssets="all" />
     <PackageReference Include="SecurityCodeScan" Version="3.5.3" PrivateAssets="all" />


### PR DESCRIPTION
Since the newest version is not yet supported in Azure DevOps.