### PR TITLE
Add .gitattributes to ensure LF on bash files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf whitespace=blank-at-eol,-blank-at-eof

--- a/atc-coding-rules-updater.sh
+++ b/atc-coding-rules-updater.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 echo "Updating atc-coding-rules-updater tool to newest version"
 dotnet tool update -g atc-coding-rules-updater
 


### PR DESCRIPTION
The bash script was with CRLF, but that causes problems with bash scripts on non-windows platforms, so these should always be with LF.
The provided .gitattributes enforces this, and I hope that the bash file is also changed, although git is really good at hiding these kings of changes.