### PR TITLE
Update requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Atc.CodingRules.Updater.CLI library is available through a cross platform co
 
 ### Requirements
 
-* .NET 6 runtime
+* [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 
 ### Installation
 


### PR DESCRIPTION
The tool actually needs .Net 6 SDK, not just the Runtime.
I also added a link to the download page.