### PR TITLE
Fix Issues #58 and #59 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <PackageReference Include="Meziantou.Analyzer" Version="1.0.688" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.34.0.42011" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.35.0.42613" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ EXAMPLES:
     atc-coding-rules-updater.exe options-file create .       (equivalent to 'options-file create -p [CurrentFolder]')
     atc-coding-rules-updater.exe options-file create -p .    (equivalent to 'options-file create -p [CurrentFolder]')
     atc-coding-rules-updater.exe options-file create -p c:\temp\MyProject
+    atc-coding-rules-updater.exe options-file create -p c:\temp\MyProject -t DotNet5
     atc-coding-rules-updater.exe options-file validate .     (equivalent to 'options-file validate -p [CurrentFolder]')
     atc-coding-rules-updater.exe options-file validate -p c:\temp\MyProject
 

--- a/README.md
+++ b/README.md
@@ -231,11 +231,6 @@ The tool has an optional options parameter, which can be used to control the pat
   "temporarySuppressionAsExcel": false,
   "analyzerProviderCollectingMode": "LocalCache",
   "mappings": {
-    "sample": {
-      "paths": [
-        "sample"
-      ]
-    },
     "src": {
       "paths": [
         "src"

--- a/src/Atc.CodingRules.AnalyzerProviders/Atc.CodingRules.AnalyzerProviders.csproj
+++ b/src/Atc.CodingRules.AnalyzerProviders/Atc.CodingRules.AnalyzerProviders.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="1.1.381" />
+    <PackageReference Include="Atc" Version="1.1.385" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.40" />
   </ItemGroup>
 

--- a/src/Atc.CodingRules.Updater.CLI/Atc.CodingRules.Updater.CLI.csproj
+++ b/src/Atc.CodingRules.Updater.CLI/Atc.CodingRules.Updater.CLI.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="1.1.381" />
-    <PackageReference Include="Atc.Console.Spectre" Version="1.1.381" />
+    <PackageReference Include="Atc" Version="1.1.385" />
+    <PackageReference Include="Atc.Console.Spectre" Version="1.1.385" />
     <PackageReference Include="EPPlus" Version="5.8.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>

--- a/src/Atc.CodingRules.Updater.CLI/Commands/OptionsFileCreateCommand.cs
+++ b/src/Atc.CodingRules.Updater.CLI/Commands/OptionsFileCreateCommand.cs
@@ -1,6 +1,6 @@
 namespace Atc.CodingRules.Updater.CLI.Commands;
 
-public class OptionsFileCreateCommand : AsyncCommand<ProjectBaseCommandSettings>
+public class OptionsFileCreateCommand : AsyncCommand<ProjectCommandSettings>
 {
     private readonly ILogger<OptionsFileCreateCommand> logger;
 
@@ -8,23 +8,22 @@ public class OptionsFileCreateCommand : AsyncCommand<ProjectBaseCommandSettings>
 
     public override Task<int> ExecuteAsync(
         CommandContext context,
-        ProjectBaseCommandSettings settings)
+        ProjectCommandSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
         return ExecuteInternalAsync(settings);
     }
 
     private async Task<int> ExecuteInternalAsync(
-        ProjectBaseCommandSettings settings)
+        ProjectCommandSettings settings)
     {
         ConsoleHelper.WriteHeader();
 
         var projectPath = new DirectoryInfo(settings.ProjectPath);
-        var optionsPath = settings.GetOptionsPath();
 
         try
         {
-            (bool isSuccessful, string error) = await OptionsHelper.CreateOptionsFile(projectPath, optionsPath);
+            (bool isSuccessful, string error) = await OptionsHelper.CreateOptionsFile(projectPath, settings);
             if (isSuccessful)
             {
                 logger.LogInformation("The options file is created");

--- a/src/Atc.CodingRules.Updater.CLI/OptionsHelper.cs
+++ b/src/Atc.CodingRules.Updater.CLI/OptionsHelper.cs
@@ -28,15 +28,22 @@ public static class OptionsHelper
 
     public static async Task<(bool, string)> CreateOptionsFile(
         DirectoryInfo projectPath,
-        string? settingsOptionsPath)
+        ProjectCommandSettings settings)
     {
-        var fileInfo = GetOptionsFile(projectPath, settingsOptionsPath);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var fileInfo = GetOptionsFile(projectPath, settings.GetOptionsPath());
         if (fileInfo.Exists)
         {
             return (false, "File already exist");
         }
 
         var options = CreateDefaultOptions();
+        if (settings.ProjectTarget.IsSet)
+        {
+            options.ProjectTarget = settings.ProjectTarget.Value;
+        }
+
         var serializeOptions = JsonSerializerOptionsFactory.Create();
         var json = JsonSerializer.Serialize(options, serializeOptions);
         await File.WriteAllTextAsync(fileInfo.FullName, json, Encoding.UTF8);

--- a/src/Atc.CodingRules.Updater/Atc.CodingRules.Updater.csproj
+++ b/src/Atc.CodingRules.Updater/Atc.CodingRules.Updater.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="1.1.381" />
-    <PackageReference Include="Atc.DotNet" Version="1.1.381" />
+    <PackageReference Include="Atc" Version="1.1.385" />
+    <PackageReference Include="Atc.DotNet" Version="1.1.385" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.CodingRules.Updater/SupportedProjectTargetType.cs
+++ b/src/Atc.CodingRules.Updater/SupportedProjectTargetType.cs
@@ -1,9 +1,8 @@
-namespace Atc.CodingRules.Updater
+namespace Atc.CodingRules.Updater;
+
+public enum SupportedProjectTargetType
 {
-    public enum SupportedProjectTargetType
-    {
-        DotNetCore,
-        DotNet5,
-        DotNet6,
-    }
+    DotNetCore,
+    DotNet5,
+    DotNet6,
 }

--- a/src/Atc.CodingRules/Atc.CodingRules.csproj
+++ b/src/Atc.CodingRules/Atc.CodingRules.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="1.1.381" />
+    <PackageReference Include="Atc" Version="1.1.385" />
   </ItemGroup>
 
 </Project>

--- a/test/Atc.CodingRules.AnalyzerProviders.Tests/Atc.CodingRules.AnalyzerProviders.Tests.csproj
+++ b/test/Atc.CodingRules.AnalyzerProviders.Tests/Atc.CodingRules.AnalyzerProviders.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
#58 has been fixed by supporting the -t projectTarget switch in `options-file create` sub-command

#59 has been fixed by making the generator slightly intelligent. If no sample folder is found, it sets the path array to empty in the json file, which is enough for later runs of `run` to not create a sample folder. If a sample folder is found, it is added to the array with the correct casing. This casing feature has also been added to the src & test folders. 

The PR also contains an update to Nuget packages.