### PR TITLE
Add .NET 11 support and harden tool bootstrap scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -586,6 +586,7 @@ dotnet_diagnostic.CA1515.severity = suggestion      # Because an application's A
 dotnet_diagnostic.CA1848.severity = none            # For improved performance, use the LoggerMessage delegates instead of calling 'LoggerExtensions.LogTrace(ILogger, string, params object[])'
 dotnet_diagnostic.CA1859.severity = none            #
 dotnet_diagnostic.CA1860.severity = none            #
+dotnet_diagnostic.CA1873.severity = none            # Avoid potentially expensive logging - aligns with CA1848/CA2254 opt-out (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873)
 dotnet_diagnostic.CA2007.severity = none            # Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2254.severity = none            # For improved performance, use the LoggerMessage delegates instead of calling 'LoggerExtensions.LogTrace(ILogger, string, params object[])'
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Atc.CodingRules.Updater.CLI library is available through a cross platform co
 The tool can be installed as a .NET Core global tool by the following command
 
 ```powershell
-dotnet tool install --global atc-coding-rules-updater
+dotnet tool install --global atc-coding-rules-updater --ignore-failed-sources
 ```
 
 or by following the instructions [here](https://www.nuget.org/packages/atc-coding-rules-updater/) to install a specific version of the tool.
@@ -64,7 +64,7 @@ Tool 'atc-coding-rules-updater' (version '2.0.xxx') was successfully installed.`
 The tool can be updated by following command
 
 ```powershell
-dotnet tool update --global atc-coding-rules-updater
+dotnet tool update --global atc-coding-rules-updater --ignore-failed-sources
 ```
 
 ### Usage
@@ -290,13 +290,13 @@ By specifying this mapping it will over-rule the automatic detection of the proj
 
 **Note:** If there is a `atc-coding-rules-updater.json` file present in the root folder (given by options `--projectPath` /  `-p`), then it will automatically be found and used. Other given arguments will then override.
 
-## CLI Tool Usage from powershell
+## CLI Tool Usage from PowerShell or Bash
 
 To ensure that the latest version of the CLI tool `atc-coding-rules-updater` is being used, the following methodology can be used:
 
 1) Download the 2 files from `sample` into a project root folder.
 2) Modify the `atc-coding-rules-updater.json` to the projects specific needs.
-3) Run `atc-coding-rules-updater.ps1` from powershell
+3) Run `atc-coding-rules-updater.ps1` from PowerShell, or `atc-coding-rules-updater.sh` from Bash (copy it from the repository root alongside the `atc-coding-rules-updater.json`).
 
 ## Deep dive in what `atc-coding-rules-updater` actual does and doesn't do
 

--- a/atc-coding-rules-updater.ps1
+++ b/atc-coding-rules-updater.ps1
@@ -1,6 +1,6 @@
 Clear-Host
 Write-Host "Updating atc-coding-rules-updater tool to newest version"
-dotnet tool update -g atc-coding-rules-updater
+dotnet tool update -g atc-coding-rules-updater --ignore-failed-sources
 
 $currentPath = Get-Location
 

--- a/atc-coding-rules-updater.sh
+++ b/atc-coding-rules-updater.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Updating atc-coding-rules-updater tool to newest version"
-dotnet tool update -g atc-coding-rules-updater
+dotnet tool update -g atc-coding-rules-updater --ignore-failed-sources
 
 currentPath=$(pwd)
 jsonPath="$currentPath/atc-coding-rules-updater.json"

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,4 +1,4 @@
-# CLI Tool Usage from PowerShell
+# CLI Tool Usage from PowerShell or Bash
 
 Utilize this sample script, to ensure always having the latest version of the `atc-coding-rules-updater` tool.
 
@@ -6,4 +6,4 @@ In order to get started, follow these 3 steps:
 
 1) Download the 2 files from `sample` folder into a project root folder.
 2) Modify the `atc-coding-rules-updater.json` to project needs.
-3) Run `atc-coding-rules-updater.ps1` from PowerShell.
+3) Run `atc-coding-rules-updater.ps1` from PowerShell, or `atc-coding-rules-updater.sh` from Bash (copy it from the repository root alongside the `atc-coding-rules-updater.json`).

--- a/sample/atc-coding-rules-updater.ps1
+++ b/sample/atc-coding-rules-updater.ps1
@@ -1,6 +1,6 @@
 Clear-Host
 Write-Host "Updating atc-coding-rules-updater tool to newest version"
-dotnet tool update -g atc-coding-rules-updater
+dotnet tool update -g atc-coding-rules-updater --ignore-failed-sources
 
 $currentPath = Get-Location
 

--- a/src/Atc.CodingRules.Updater.CLI/ProjectHelper.cs
+++ b/src/Atc.CodingRules.Updater.CLI/ProjectHelper.cs
@@ -35,7 +35,8 @@ public static class ProjectHelper
             or SupportedProjectTargetType.DotNet7
             or SupportedProjectTargetType.DotNet8
             or SupportedProjectTargetType.DotNet9
-            or SupportedProjectTargetType.DotNet10)
+            or SupportedProjectTargetType.DotNet10
+            or SupportedProjectTargetType.DotNet11)
         {
             HandleDirectoryBuildPropsFiles(logger, projectPath, options);
 

--- a/src/Atc.CodingRules.Updater/ProjectSanityCheckHelper.cs
+++ b/src/Atc.CodingRules.Updater/ProjectSanityCheckHelper.cs
@@ -22,6 +22,7 @@ public static class ProjectSanityCheckHelper
             case SupportedProjectTargetType.DotNet8:
             case SupportedProjectTargetType.DotNet9:
             case SupportedProjectTargetType.DotNet10:
+            case SupportedProjectTargetType.DotNet11:
                 HasTargetFrameworkAndImplicitUsings(throwIf, logger, projectPath, "netcoreapp3.1");
                 break;
         }

--- a/src/Atc.CodingRules.Updater/SupportedProjectTargetType.cs
+++ b/src/Atc.CodingRules.Updater/SupportedProjectTargetType.cs
@@ -9,4 +9,5 @@ public enum SupportedProjectTargetType
     DotNet8,  // LTS
     DotNet9,  // STS
     DotNet10, // LTS
+    DotNet11, // STS
 }


### PR DESCRIPTION
  # Summary

  - Add .NET 11 as a supported project target type
  - Prevent bootstrap scripts from aborting on unreachable feeds
  - Document Bash usage alongside the existing PowerShell path

  # Changes

  ### :sparkles: Features
  - Add DotNet11 (STS) to SupportedProjectTargetType enum
  - Wire DotNet11 through sanity check and Directory.Build.props

  ### :bug: Fixes
  - Pass --ignore-failed-sources to dotnet tool install/update
  - Keep bootstrap working when a repo nuget.config clears sources
  - Avoid auth failures on private Azure DevOps feeds aborting run

  ### :memo: Documentation
  - Mirror --ignore-failed-sources in README install/update commands
  - Retitle usage section to "PowerShell or Bash" in both READMEs
  - Point Bash users at atc-coding-rules-updater.sh in repo root
