### PR TITLE
fix(atc-api): repoint base URL to Azure Container Apps host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,5 @@ jobs:
       - name: 🌩️ ATC-API invalidate cache for CLI-Tool
         uses: satak/webrequest-action@master
         with:
-          url: https://atc-api.azurewebsites.net/nuget-search/package?packageId=atc-coding-rules-updater&invalidateCache=true
+          url: https://atcnet-api-prod-api-ca-01.greenhill-862ffb7c.swedencentral.azurecontainerapps.io/nuget-search/package?packageId=atc-coding-rules-updater&invalidateCache=true
           method: GET

--- a/src/Atc.CodingRules/AtcApiNugetClientHelper.cs
+++ b/src/Atc.CodingRules/AtcApiNugetClientHelper.cs
@@ -2,7 +2,7 @@ namespace Atc.CodingRules;
 
 public static class AtcApiNugetClientHelper
 {
-    private const string BaseAddress = "https://atc-api.azurewebsites.net/nuget-search";
+    private const string BaseAddress = "https://atcnet-api-prod-api-ca-01.greenhill-862ffb7c.swedencentral.azurecontainerapps.io/nuget-search";
     private static readonly ConcurrentDictionary<string, Version> Cache = new(StringComparer.Ordinal);
     private static readonly HttpClient SharedClient = new();
 


### PR DESCRIPTION
  - Update AtcApiNugetClientHelper.BaseAddress to new Sweden Central ACA endpoint
  - Update release workflow cache-invalidation URL to match