### PR TITLE
Fix broken emojiees in console

### DIFF
--- a/src/Atc.CodingRules.Updater.CLI/Program.cs
+++ b/src/Atc.CodingRules.Updater.CLI/Program.cs
@@ -10,6 +10,11 @@ public static class Program
     {
         ArgumentNullException.ThrowIfNull(args);
 
+        // Must happen before ServiceCollectionFactory.Create, which snapshots the console for the
+        // logger. CommandAppFactory sets UTF-8 too, but it runs after that snapshot is taken, so on
+        // a console using an OEM code page every emoji written by the logger degrades to '?'.
+        System.Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         args = SetProjectPathFromDotArgumentIfNeeded(args);
         args = SetHelpArgumentIfNeeded(args);
 


### PR DESCRIPTION
fix(cli): restore emoji output in the console logger

Set Console.OutputEncoding to UTF-8 as the first statement in Main.

The emoji regressed to ? in 2.0.266. The cause is the Atc 3.0.67 -> 3.0.181 bump in c5402df (which also moves Spectre.Console 0.55.2 -> 0.57.2), not a change in this repository: Program.Main has the same startup order it had in 2.0.253.

In 3.0.181, ServiceCollectionFactory.Create snapshots the console for the logger. CommandAppFactory.CreateWithRootCommand does assign Console.OutputEncoding = UTF8, but every caller invokes it after the service collection is built, so the snapshot has already captured the OEM code page the process started on (437 on a default Windows console). The logger then keeps that encoder for the rest of the run and each emoji hits its replacement fallback - one ? per UTF-16 code unit, hence ? for BMP emoji such as the check mark and ?? for surrogate pairs such as the mouse face and hammer.

Only the ILogger path is affected. AnsiConsole and System.Console both emit correct UTF-8, which is why the figlet header still rendered.

This is a workaround. The defect belongs upstream in atc-net/atc, where the encoding assignment and the console capture need to happen in the opposite order. Pinning Atc back is not an option here, since the same commit adopts NetworkInformationHelper.HasHttpConnectionAsync, the 10-argument DotnetBuildHelper.BuildAndCollectErrors and BuildAndCollectWarnings.

Verified at the byte level: the success emoji is E2 9C 85 again, matching 2.0.253, and a full run renders the area emoji as expected. @